### PR TITLE
PDE-1428: fix HIVE_PATH_ALREADY_EXISTS error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ cython_debug/
 
 # Project specific
 test.py
+
+# pyenv
+.python-version

--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,7 +1,5 @@
 {% macro athena__drop_relation(relation) -%}
-  {% if config.get('incremental_strategy') != 'append' %}
-    {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
-  {% endif %}
+  {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
     drop {{ relation.type }} if exists {{ relation }}
   {%- endcall %}

--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,5 +1,7 @@
 {% macro athena__drop_relation(relation) -%}
-  {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
+  {% if config.get('incremental_strategy') != 'append' %}
+    {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
+  {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}
     drop {{ relation.type }} if exists {{ relation }}
   {%- endcall %}

--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,5 +1,5 @@
 {% macro athena__drop_relation(relation) -%}
-  {% if config.get('incremental_strategy') == 'insert_overwrite' %}
+  {% if config.get('incremental_strategy') != 'append' %}
     {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
   {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}


### PR DESCRIPTION
This PR relates to the change in [this](https://github.com/Tomme/dbt-athena/pull/49) PR which is now out of date and needs refactoring for v1.0.* of dbt-athena.
An issue has been raised in the main dbt-athena repo, [here](https://github.com/Tomme/dbt-athena/issues/54).

A more detailed investigation into the expected behaviour of the `append` and `insert_overwrite` incremental strategies will be needed, so for the time being this PR removes the conditional so that we can reliably work with the `table` materialisation.