### PR TITLE
PDE-1813: Use dbt profile specified data bucket and env to generate model and seed write path

### DIFF
--- a/dbt/adapters/athena/__init__.py
+++ b/dbt/adapters/athena/__init__.py
@@ -10,5 +10,5 @@ from dbt.include import athena
 Plugin = AdapterPlugin(
     adapter=AthenaAdapter,
     credentials=AthenaCredentials,
-    include_path=athena.PACKAGE_PATH
+    include_path=athena.PACKAGE_PATH,
 )

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -150,6 +150,7 @@ class AthenaConnectionManager(SQLConnectionManager):
 
             handle = AthenaConnection(
                 s3_staging_dir=creds.s3_staging_dir,
+                s3_data_dir=creds.s3_data_dir,
                 endpoint_url=creds.endpoint_url,
                 region_name=creds.region_name,
                 schema_name=creds.schema,

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -150,7 +150,6 @@ class AthenaConnectionManager(SQLConnectionManager):
 
             handle = AthenaConnection(
                 s3_staging_dir=creds.s3_staging_dir,
-                s3_data_dir=creds.s3_data_dir,
                 endpoint_url=creds.endpoint_url,
                 region_name=creds.region_name,
                 schema_name=creds.schema,

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -44,11 +44,28 @@ class AthenaAdapter(SQLAdapter):
         return "timestamp"
 
     @available
-    def s3_uuid_table_location(self):
+    def generate_s3_data_path(
+        self,
+        env_name: str,
+        domain_name: str,
+        schema_name: str,
+        table_name: str,
+        run_time: Optional[str] = None,
+    ) -> str:
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
-        return f"{client.s3_staging_dir}tables/{str(uuid4())}/"
+        if run_time is None:
+            return (
+                f"{client.s3_data_dir}/env_name={env_name}/domain_name={domain_name}/"
+                f"database_name={schema_name}/table_name={table_name}"
+            )
+        else:
+            return (
+                f"{client.s3_data_dir}/env_name={env_name}/domain_name={domain_name}/"
+                f"database_name={schema_name}/table_name={table_name}/"
+                f"run_time={run_time}"
+            )
 
     @available
     def clean_up_partitions(
@@ -132,13 +149,14 @@ class AthenaAdapter(SQLAdapter):
         results = self._catalog_filter_table(table, manifest)
         return results
 
-
     def _get_catalog_schemas(self, manifest: Manifest) -> AthenaSchemaSearchMap:
         info_schema_name_map = AthenaSchemaSearchMap()
         nodes: Iterator[CompileResultNode] = chain(
-            [node for node in manifest.nodes.values() if (
-                node.is_relational and not node.is_ephemeral_model
-            )],
+            [
+                node
+                for node in manifest.nodes.values()
+                if (node.is_relational and not node.is_ephemeral_model)
+            ],
             manifest.sources.values(),
         )
         for node in nodes:

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -5,7 +5,6 @@ from botocore.exceptions import ClientError
 from itertools import chain
 from threading import Lock
 from typing import Dict, Iterator, Optional, Set
-from uuid import uuid4
 
 from dbt.adapters.base import available
 from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -57,12 +57,12 @@ class AthenaAdapter(SQLAdapter):
 
         if run_time is None:
             return (
-                f"{client.s3_data_dir}/env_name={env_name}/domain_name={domain_name}/"
+                f"{client.s3_data_dir}/{env_name}/domain_name={domain_name}/"
                 f"database_name={schema_name}/table_name={table_name}"
             )
         else:
             return (
-                f"{client.s3_data_dir}/env_name={env_name}/domain_name={domain_name}/"
+                f"{client.s3_data_dir}/{env_name}/domain_name={domain_name}/"
                 f"database_name={schema_name}/table_name={table_name}/"
                 f"run_time={run_time}"
             )

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -53,7 +53,7 @@ class AthenaAdapter(SQLAdapter):
         run_time: Optional[str] = None,
     ) -> str:
         conn = self.connections.get_thread_connection()
-        client = conn.handle
+        client = conn.credentials
 
         if run_time is None:
             return (

--- a/dbt/adapters/athena/query_headers.py
+++ b/dbt/adapters/athena/query_headers.py
@@ -1,13 +1,15 @@
 import dbt.adapters.base.query_headers
 
+
 class _QueryComment(dbt.adapters.base.query_headers._QueryComment):
     """
-    Athena DDL does not always respect /* ... */ block quotations. 
-    This function is the same as _QueryComment.add except that 
+    Athena DDL does not always respect /* ... */ block quotations.
+    This function is the same as _QueryComment.add except that
     a leading "-- " is prepended to the query_comment and any newlines
     in the query_comment are replaced with " ". This allows the default
     query_comment to be added to `create external table` statements.
     """
+
     def add(self, sql: str) -> str:
         if not self.query_comment:
             return sql
@@ -17,11 +19,17 @@ class _QueryComment(dbt.adapters.base.query_headers._QueryComment):
             sql = sql.rstrip()
             if sql[-1] == ";":
                 sql = sql[:-1]
-                return "{}\n-- /* {} */;".format(sql, self.query_comment.strip().replace("\n", " "))
+                return "{}\n-- /* {} */;".format(
+                    sql, self.query_comment.strip().replace("\n", " ")
+                )
 
-            return "{}\n-- /* {} */".format(sql, self.query_comment.strip().replace("\n", " "))
+            return "{}\n-- /* {} */".format(
+                sql, self.query_comment.strip().replace("\n", " ")
+            )
 
-        return "-- /* {} */\n{}".format(self.query_comment.strip().replace("\n", " "), sql)
+        return "-- /* {} */\n{}".format(
+            self.query_comment.strip().replace("\n", " "), sql
+        )
 
 
 dbt.adapters.base.query_headers._QueryComment = _QueryComment

--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Set 
+from typing import Dict, Optional, Set
 
 from dbt.adapters.base.relation import BaseRelation, InformationSchema, Policy
 
@@ -16,11 +16,13 @@ class AthenaRelation(BaseRelation):
     quote_character: str = ""
     include_policy: Policy = AthenaIncludePolicy()
 
+
 class AthenaSchemaSearchMap(Dict[InformationSchema, Dict[str, Set[Optional[str]]]]):
     """A utility class to keep track of what information_schema tables to
     search for what schemas and relations. The schema and relation values are all
     lowercased to avoid duplication.
     """
+
     def add(self, relation: AthenaRelation):
         key = relation.information_schema_only()
         if key not in self:

--- a/dbt/include/athena/__init__.py
+++ b/dbt/include/athena/__init__.py
@@ -1,2 +1,3 @@
 import os
+
 PACKAGE_PATH = os.path.dirname(__file__)

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -3,7 +3,7 @@
   {%- set domain_name = split_model_path[0] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
-    {%- set database_name = split_model_path[1] + '_' + env_name -%}
+    {%- set database_name = split_model_path[1] + '_dbt_' + env_name -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
     {%- set database_name = split_model_path[1] -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -2,13 +2,21 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
+  {%- if database_name.endswith("_dev") -%}
+    {%- set env_name = "dev" -%}
+  {%- else -%}
+    {%- set env_name = "prod" -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
-  {%- set extraction_timestamp = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}
+  {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}
   {%-
-    set default_external_location = 's3://mojap-derived-tables/domain_name='
-    + domain_name + '/database_name=' + database_name + '/table_name=' + table_name
-    + '/extraction_timestamp=' + extraction_timestamp + '/'
+    set default_external_location = adapter.generate_s3_data_path(
+      env_name,
+      domain_name,
+      database_name,
+      table_name,
+      run_time
+    )
   -%}
   {%-
     set external_location = config.get(

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -1,12 +1,12 @@
 {% macro athena__create_table_as(temporary, relation, sql) -%}
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
-  {%- set split_node_name = node.name.split('__') -%}
-  {%- set schema_name = split_node_name[0] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
+    {%- set database_name = split_model_path[1] + env_name -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
+    {%- set database_name = split_model_path[1] -%}
   {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
@@ -15,7 +15,7 @@
     set default_external_location = adapter.generate_s3_data_path(
       env_name,
       domain_name,
-      schema_name,
+      database_name,
       table_name,
       run_time
     )

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -3,7 +3,7 @@
   {%- set domain_name = split_model_path[0] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
-    {%- set database_name = split_model_path[1] + env_name -%}
+    {%- set database_name = split_model_path[1] + '_' + env_name -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
     {%- set database_name = split_model_path[1] -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -2,10 +2,14 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
-  {%- set env_name = "dev" if database_name.endswith("_dev") else "prod" -%}
+  {%- if target.get('profile_name')=='dev' -%}
+    {%- set env_name = 'dev' -%}
+  {%- else -%}
+    {%- set env_name = 'prod' -%}
+  {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
-  {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}
+  {%- set run_time = run_started_at.strftime('%Y-%m-%d %H:%M:%S') -%}
   {%-
     set default_external_location = adapter.generate_s3_data_path(
       env_name,

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -2,7 +2,7 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
-  {%- if target.get('profile_name')=='dev' -%}
+  {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -2,11 +2,7 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
-  {%- if database_name.endswith("_dev") -%}
-    {%- set env_name = "dev" -%}
-  {%- else -%}
-    {%- set env_name = "prod" -%}
-  {%- endif -%}
+  {%- set env_name = "dev" if database_name.endswith("_dev") else "prod" -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -1,12 +1,11 @@
 {% macro athena__create_table_as(temporary, relation, sql) -%}
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
+  {%- set database_name = split_model_path[1] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
-    {%- set database_name = split_model_path[1] + '_dbt_' + env_name -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
-    {%- set database_name = split_model_path[1] -%}
   {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -3,7 +3,7 @@
   {%- set domain_name = split_model_path[0] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
-    {%- set database_name = split_model_path[1] + '_dbt_{{ env_name }}' -%}
+    {%- set database_name = split_model_path[1] + '_dbt_' + env_name -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
     {%- set database_name = split_model_path[1] -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -1,7 +1,8 @@
 {% macro athena__create_table_as(temporary, relation, sql) -%}
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
-  {%- set database_name = split_model_path[1] -%}
+  {%- set split_node_name = node.name.split('__') -%}
+  {%- set schema_name = split_node_name[0] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
   {%- else -%}
@@ -14,7 +15,7 @@
     set default_external_location = adapter.generate_s3_data_path(
       env_name,
       domain_name,
-      database_name,
+      schema_name,
       table_name,
       run_time
     )

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -6,6 +6,7 @@
     {%- set env_name = "dev" -%}
   {%- else -%}
     {%- set env_name = "prod" -%}
+  {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -1,11 +1,12 @@
 {% macro athena__create_table_as(temporary, relation, sql) -%}
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
-  {%- set database_name = split_model_path[1] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
+    {%- set database_name = split_model_path[1] + '_dbt_{{ env_name }}' -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
+    {%- set database_name = split_model_path[1] -%}
   {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -14,10 +14,14 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
-  {%- set env_name = "dev" if database_name.endswith("_dev") else "prod" -%}
+  {%- if target.get('profile_name')=='dev' -%}
+    {%- set env_name = 'dev' -%}
+  {%- else -%}
+    {%- set env_name = 'prod' -%}
+  {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
-  {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}
+  {%- set run_time = run_started_at.strftime('%Y-%m-%d %H:%M:%S') -%}
   {%-
     set default_external_location = adapter.generate_s3_data_path(
       env_name,

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -18,6 +18,7 @@
     {%- set env_name = "dev" -%}
   {%- else -%}
     {%- set env_name = "prod" -%}
+  {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -13,11 +13,12 @@
 
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
-  {%- set database_name = split_model_path[1] -%}
   {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
+    {%- set database_name = split_model_path[1] + '_dbt_' + env_name -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}
+    {%- set database_name = split_model_path[1] -%}
   {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -14,11 +14,7 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
-  {%- if database_name.endswith("_dev") -%}
-    {%- set env_name = "dev" -%}
-  {%- else -%}
-    {%- set env_name = "prod" -%}
-  {%- endif -%}
+  {%- set env_name = "dev" if database_name.endswith("_dev") else "prod" -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -11,6 +11,26 @@
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
 
+  {%- set split_model_path = model.path.split('/') -%}
+  {%- set domain_name = split_model_path[0] -%}
+  {%- set database_name = split_model_path[1] -%}
+  {%- if database_name.endswith("_dev") -%}
+    {%- set env_name = "dev" -%}
+  {%- else -%}
+    {%- set env_name = "prod" -%}
+  {%- set file_name = split_model_path[-1].split('.')[0] -%}
+  {%- set table_name = file_name.split('__')[-1] -%}
+  {%- set run_time = run_started_at.strftime("%Y-%m-%d %H:%M:%S") -%}
+  {%-
+    set default_external_location = adapter.generate_s3_data_path(
+      env_name,
+      domain_name,
+      database_name,
+      table_name,
+      run_time
+    )
+  -%}
+
   {% set sql %}
     create external table {{ this.render() }} (
         {%- for col_name in agate_table.column_names -%}
@@ -21,7 +41,7 @@
         {%- endfor -%}
     )
     stored as parquet
-    location '{{ adapter.s3_uuid_table_location() }}'
+    location '{{ default_external_location }}'
     tblproperties ('classification'='parquet')
   {% endset %}
 

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -14,7 +14,7 @@
   {%- set split_model_path = model.path.split('/') -%}
   {%- set domain_name = split_model_path[0] -%}
   {%- set database_name = split_model_path[1] -%}
-  {%- if target.get('profile_name')=='dev' -%}
+  {%- if target.get('target_name')=='dev' -%}
     {%- set env_name = 'dev' -%}
   {%- else -%}
     {%- set env_name = 'prod' -%}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import re
 
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, 'README.md')) as f:
+with open(os.path.join(this_directory, "README.md")) as f:
     long_description = f.read()
 
 
@@ -21,7 +21,7 @@ def _dbt_athena_version() -> str:
     with open(_version_path) as f:
         match = re.search(_version_pattern, f.read().strip())
         if match is None:
-            raise ValueError(f'invalid version at {_version_path}')
+            raise ValueError(f"invalid version at {_version_path}")
         return match.group(1)
 
 
@@ -41,11 +41,9 @@ if not package_version.startswith(dbt_version):
 setup(
     name=package_name,
     version=package_version,
-
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
-
+    long_description_content_type="text/markdown",
     author="Thomas Elvey",
     author_email="tomelvey@googlemail.com",
     url="https://github.com/Tomme/dbt-athena",
@@ -56,5 +54,5 @@ setup(
         "pyathena==2.2.0",
         "boto3==1.18.12",
         "tenacity==6.3.1",
-    ]
+    ],
 )


### PR DESCRIPTION
This PR updates the adapter so that a standard S3 path can be generated for models and seeds. The path uses the target profile value to determine whether the tables are to be written to a database with the `_dbt_dev` suffix or not.
A lot of the changes are just Black formatting updates. The files I've changed are `connections.py`, `impl.py`, `create_table_as.sql`, and `helpers.sql`.

#### Some thoughts
- The changes are very specific to our use case and would not be accepted to be merged into the main package.
- As we move to a more specific package, we'll need to update the readme.