### PR TITLE
DATA-111: add seeds prefix to data bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,17 @@ stored login info. You can configure the AWS profile name to use via `aws_profil
 
 A dbt profile can be configured to run against AWS Athena using the following configuration:
 
-| Option          | Description                                                                     | Required?  | Example             |
-|---------------- |-------------------------------------------------------------------------------- |----------- |-------------------- |
-| s3_staging_dir  | S3 location to store Athena query results and metadata                          | Required   | `s3://bucket/dbt/`  |
-| region_name     | AWS region of your Athena instance                                              | Required   | `eu-west-1`         |
-| schema          | Specify the schema (Athena database) to build models into (lowercase **only**)  | Required   | `dbt`               |
-| database        | Specify the database (Data catalog) to build models into (lowercase **only**)   | Required   | `awsdatacatalog`    |
-| poll_interval   | Interval in seconds to use for polling the status of query results in Athena    | Optional   | `5`                 |
-| aws_profile_name| Profile to use from your AWS shared credentials file.                           | Optional   | `my-profile`        |
-| work_group| Identifier of Athena workgroup   | Optional   | `my-custom-workgroup`        |
-| num_retries| Number of times to retry a failing query | Optional  | `3`  | `5`
+| Option            | Description                                                                    | Required? | Example               |
+|-------------------|--------------------------------------------------------------------------------|-----------|-----------------------|
+| query_dump_bucket | S3 bucket to store Athena query results and metadata                           | Required  | `bucket/dbt/`         |
+| data_bucket       | S3 bucket to store data written out by dbt                                     | Required  | `bucket/dbt/`         |
+| region_name       | AWS region of your Athena instance                                             | Required  | `eu-west-1`           |
+| schema            | Specify the schema (Athena database) to build models into (lowercase **only**) | Required  | `dbt`                 |
+| database          | Specify the database (Data catalog) to build models into (lowercase **only**)  | Required  | `awsdatacatalog`      |
+| poll_interval     | Interval in seconds to use for polling the status of query results in Athena   | Optional  | `5`                   |
+| aws_profile_name  | Profile to use from your AWS shared credentials file.                          | Optional  | `my-profile`          |
+| work_group        | Identifier of Athena workgroup                                                 | Optional  | `my-custom-workgroup` |
+| num_retries       | Number of times to retry a failing query                                       | Optional  | `5`                   |
 
 **Example profiles.yml entry:**
 ```yaml
@@ -59,7 +60,8 @@ athena:
   outputs:
     dev:
       type: athena
-      s3_staging_dir: s3://athena-query-results/dbt/
+      query_dump_bucekt: athena-query-results/dbt/
+      data_bucket: dbt-derived-tables
       region_name: eu-west-1
       schema: dbt
       database: awsdatacatalog
@@ -79,7 +81,8 @@ _Additional information_
 
 * `external_location` (`default=none`)
   * The location where Athena saves your table in Amazon S3
-  * If `none` then it will default to `{s3_staging_dir}/tables`
+  * For models if `none` then it will default to `s3://{data_bucket}/{env_name}/models/domain_name={domain_name}/database_name={schema_name}/table_name={table_name}`
+  * For seeds if `none` then it will default to `s3://{data_bucket}/{env_name}/seeds/domain_name={domain_name}/database_name={schema_name}/table_name={table_name}`
   * If you are using a static value, when your table/partition is recreated underlying data will be cleaned up and overwritten by new data
 * `partitioned_by` (`default=none`)
   * An array list of columns by which the table will be partitioned

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ _Additional information_
 
 * `external_location` (`default=none`)
   * The location where Athena saves your table in Amazon S3
-  * For models if `none` then it will default to `s3://{data_bucket}/{env_name}/models/domain_name={domain_name}/database_name={schema_name}/table_name={table_name}`
-  * For seeds if `none` then it will default to `s3://{data_bucket}/{env_name}/seeds/domain_name={domain_name}/database_name={schema_name}/table_name={table_name}`
+  * For models if `none` then it will default to `{s3_data_dir}/{env_name}/models/domain_name={domain_name}/database_name={schema_name}/table_name={table_name}`
+  * For seeds if `none` then it will default to `{s3_data_dir}/{env_name}/seeds/domain_name={domain_name}/database_name={schema_name}/table_name={table_name}`
   * If you are using a static value, when your table/partition is recreated underlying data will be cleaned up and overwritten by new data
 * `partitioned_by` (`default=none`)
   * An array list of columns by which the table will be partitioned

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ A dbt profile can be configured to run against AWS Athena using the following co
 
 | Option            | Description                                                                    | Required? | Example               |
 |-------------------|--------------------------------------------------------------------------------|-----------|-----------------------|
-| query_dump_bucket | S3 bucket to store Athena query results and metadata                           | Required  | `bucket/dbt/`         |
-| data_bucket       | S3 bucket to store data written out by dbt                                     | Required  | `bucket/dbt/`         |
+| s3_staging_dir    | S3 location to store Athena query results and metadata                         | Required  | `bucket/dbt/`         |
+| s3_data_dir       | S3 location to store data written out by dbt                                   | Required  | `bucket/dbt/`         |
 | region_name       | AWS region of your Athena instance                                             | Required  | `eu-west-1`           |
 | schema            | Specify the schema (Athena database) to build models into (lowercase **only**) | Required  | `dbt`                 |
 | database          | Specify the database (Data catalog) to build models into (lowercase **only**)  | Required  | `awsdatacatalog`      |
@@ -60,8 +60,8 @@ athena:
   outputs:
     dev:
       type: athena
-      query_dump_bucekt: athena-query-results/dbt/
-      data_bucket: dbt-derived-tables
+      s3_staging_dir: athena-query-results/dbt/
+      s3_data_dir: dbt-derived-tables
       region_name: eu-west-1
       schema: dbt
       database: awsdatacatalog

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -32,8 +32,8 @@ logger = AdapterLogger("Athena")
 
 @dataclass
 class AthenaCredentials(Credentials):
-    s3_staging_dir: str
-    s3_data_dir: str
+    query_dump_bucket: str
+    data_bucket: str
     region_name: str
     schema: str
     endpoint_url: Optional[str] = None
@@ -53,8 +53,8 @@ class AthenaCredentials(Credentials):
 
     def _connection_keys(self) -> Tuple[str, ...]:
         return (
-            "s3_staging_dir",
-            "s3_data_dir",
+            "query_dump_bucket",
+            "data_bucket",
             "work_group",
             "region_name",
             "database",
@@ -85,7 +85,7 @@ class AthenaCursor(Cursor):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         work_group: Optional[str] = None,
-        s3_staging_dir: Optional[str] = None,
+        query_dump_bucket: Optional[str] = None,
         endpoint_url: Optional[str] = None,
         cache_size: int = 0,
         cache_expiration_time: int = 0,
@@ -95,7 +95,7 @@ class AthenaCursor(Cursor):
                 operation,
                 parameters=parameters,
                 work_group=work_group,
-                s3_staging_dir=s3_staging_dir,
+                s3_staging_dir=query_dump_bucket,
                 cache_size=cache_size,
                 cache_expiration_time=cache_expiration_time,
             )
@@ -149,7 +149,7 @@ class AthenaConnectionManager(SQLConnectionManager):
             creds: AthenaCredentials = connection.credentials
 
             handle = AthenaConnection(
-                s3_staging_dir=creds.s3_staging_dir,
+                s3_staging_dir=creds.query_dump_bucket,
                 endpoint_url=creds.endpoint_url,
                 region_name=creds.region_name,
                 schema_name=creds.schema,

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -32,8 +32,8 @@ logger = AdapterLogger("Athena")
 
 @dataclass
 class AthenaCredentials(Credentials):
-    query_dump_bucket: str
-    data_bucket: str
+    s3_staging_dir: str
+    s3_data_dir: str
     region_name: str
     schema: str
     endpoint_url: Optional[str] = None
@@ -53,8 +53,8 @@ class AthenaCredentials(Credentials):
 
     def _connection_keys(self) -> Tuple[str, ...]:
         return (
-            "query_dump_bucket",
-            "data_bucket",
+            "s3_staging_dir",
+            "s3_data_dir",
             "work_group",
             "region_name",
             "database",
@@ -85,7 +85,7 @@ class AthenaCursor(Cursor):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         work_group: Optional[str] = None,
-        query_dump_bucket: Optional[str] = None,
+        s3_staging_dir: Optional[str] = None,
         endpoint_url: Optional[str] = None,
         cache_size: int = 0,
         cache_expiration_time: int = 0,
@@ -95,7 +95,7 @@ class AthenaCursor(Cursor):
                 operation,
                 parameters=parameters,
                 work_group=work_group,
-                s3_staging_dir=query_dump_bucket,
+                s3_staging_dir=s3_staging_dir,
                 cache_size=cache_size,
                 cache_expiration_time=cache_expiration_time,
             )
@@ -149,7 +149,7 @@ class AthenaConnectionManager(SQLConnectionManager):
             creds: AthenaCredentials = connection.credentials
 
             handle = AthenaConnection(
-                s3_staging_dir=creds.query_dump_bucket,
+                s3_staging_dir=creds.s3_staging_dir,
                 endpoint_url=creds.endpoint_url,
                 region_name=creds.region_name,
                 schema_name=creds.schema,

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -4,7 +4,7 @@ import boto3
 from botocore.exceptions import ClientError
 from itertools import chain
 from threading import Lock
-from typing import Dict, Iterator, Optional, Set
+from typing import Dict, Iterator, Literal, Optional, Set
 
 from dbt.adapters.base import available
 from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME
@@ -49,20 +49,14 @@ class AthenaAdapter(SQLAdapter):
         domain_name: str,
         schema_name: str,
         table_name: str,
-        model: bool,
+        table_type: Literal["models", "seeds"],
     ) -> str:
         conn = self.connections.get_thread_connection()
         client = conn.credentials
-        if model:
-            return (
-                f"{client.s3_data_dir}/{env_name}/models/domain_name={domain_name}/"
-                f"database_name={schema_name}/table_name={table_name}"
-            )
-        else:
-            return (
-                f"{client.s3_data_dir}/{env_name}/seeds/domain_name={domain_name}/"
-                f"database_name={schema_name}/table_name={table_name}"
-            )
+        return (
+            f"{client.s3_data_dir}/{env_name}/{table_type}/domain_name={domain_name}/"
+            f"database_name={schema_name}/table_name={table_name}"
+        )
 
     @available
     def clean_up_partitions(

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -54,7 +54,7 @@ class AthenaAdapter(SQLAdapter):
         client = conn.credentials
 
         return (
-            f"s3://{client.data_bucket}/{env_name}/models/domain_name={domain_name}/"
+            f"{client.data_bucket}/{env_name}/models/domain_name={domain_name}/"
             f"database_name={schema_name}/table_name={table_name}"
         )
 
@@ -70,7 +70,7 @@ class AthenaAdapter(SQLAdapter):
         client = conn.credentials
 
         return (
-            f"s3://{client.data_bucket}/{env_name}/seeds/domain_name={domain_name}/"
+            f"{client.data_bucket}/{env_name}/seeds/domain_name={domain_name}/"
             f"database_name={schema_name}/table_name={table_name}"
         )
 

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -43,36 +43,26 @@ class AthenaAdapter(SQLAdapter):
         return "timestamp"
 
     @available
-    def generate_models_s3_write_path(
+    def generate_s3_write_path(
         self,
         env_name: str,
         domain_name: str,
         schema_name: str,
         table_name: str,
+        model: bool,
     ) -> str:
         conn = self.connections.get_thread_connection()
         client = conn.credentials
-
-        return (
-            f"{client.s3_data_dir}/{env_name}/models/domain_name={domain_name}/"
-            f"database_name={schema_name}/table_name={table_name}"
-        )
-
-    @available
-    def generate_seeds_s3_write_path(
-        self,
-        env_name: str,
-        domain_name: str,
-        schema_name: str,
-        table_name: str,
-    ) -> str:
-        conn = self.connections.get_thread_connection()
-        client = conn.credentials
-
-        return (
-            f"{client.s3_data_dir}/{env_name}/seeds/domain_name={domain_name}/"
-            f"database_name={schema_name}/table_name={table_name}"
-        )
+        if model:
+            return (
+                f"{client.s3_data_dir}/{env_name}/models/domain_name={domain_name}/"
+                f"database_name={schema_name}/table_name={table_name}"
+            )
+        else:
+            return (
+                f"{client.s3_data_dir}/{env_name}/seeds/domain_name={domain_name}/"
+                f"database_name={schema_name}/table_name={table_name}"
+            )
 
     @available
     def clean_up_partitions(

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -43,28 +43,36 @@ class AthenaAdapter(SQLAdapter):
         return "timestamp"
 
     @available
-    def generate_s3_data_path(
+    def generate_models_s3_write_path(
         self,
         env_name: str,
         domain_name: str,
         schema_name: str,
         table_name: str,
-        run_time: Optional[str] = None,
     ) -> str:
         conn = self.connections.get_thread_connection()
         client = conn.credentials
 
-        if run_time is None:
-            return (
-                f"{client.s3_data_dir}/{env_name}/domain_name={domain_name}/"
-                f"database_name={schema_name}/table_name={table_name}"
-            )
-        else:
-            return (
-                f"{client.s3_data_dir}/{env_name}/domain_name={domain_name}/"
-                f"database_name={schema_name}/table_name={table_name}/"
-                f"run_time={run_time}"
-            )
+        return (
+            f"s3://{client.data_bucket}/{env_name}/models/domain_name={domain_name}/"
+            f"database_name={schema_name}/table_name={table_name}"
+        )
+
+    @available
+    def generate_seeds_s3_write_path(
+        self,
+        env_name: str,
+        domain_name: str,
+        schema_name: str,
+        table_name: str,
+    ) -> str:
+        conn = self.connections.get_thread_connection()
+        client = conn.credentials
+
+        return (
+            f"s3://{client.data_bucket}/{env_name}/seeds/domain_name={domain_name}/"
+            f"database_name={schema_name}/table_name={table_name}"
+        )
 
     @available
     def clean_up_partitions(

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -54,7 +54,7 @@ class AthenaAdapter(SQLAdapter):
         client = conn.credentials
 
         return (
-            f"{client.data_bucket}/{env_name}/models/domain_name={domain_name}/"
+            f"{client.s3_data_dir}/{env_name}/models/domain_name={domain_name}/"
             f"database_name={schema_name}/table_name={table_name}"
         )
 
@@ -70,7 +70,7 @@ class AthenaAdapter(SQLAdapter):
         client = conn.credentials
 
         return (
-            f"{client.data_bucket}/{env_name}/seeds/domain_name={domain_name}/"
+            f"{client.s3_data_dir}/{env_name}/seeds/domain_name={domain_name}/"
             f"database_name={schema_name}/table_name={table_name}"
         )
 

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -16,7 +16,7 @@
       domain_name,
       database_name,
       table_name,
-      models
+      'models'
     )
   -%}
   {%-

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -11,11 +11,12 @@
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%-
-    set default_external_location = adapter.generate_models_s3_write_path(
+    set default_external_location = adapter.generate_s3_write_path(
       env_name,
       domain_name,
       database_name,
-      table_name
+      table_name,
+      true
     )
   -%}
   {%-

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -10,14 +10,12 @@
   {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
-  {%- set run_time = run_started_at.strftime('%Y-%m-%d %H:%M:%S') -%}
   {%-
     set default_external_location = adapter.generate_s3_data_path(
       env_name,
       domain_name,
       database_name,
-      table_name,
-      run_time
+      table_name
     )
   -%}
   {%-

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -16,7 +16,7 @@
       domain_name,
       database_name,
       table_name,
-      true
+      models
     )
   -%}
   {%-

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -11,7 +11,7 @@
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%-
-    set default_external_location = adapter.generate_s3_data_path(
+    set default_external_location = adapter.generate_models_s3_write_path(
       env_name,
       domain_name,
       database_name,

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -23,11 +23,12 @@
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
   {%-
-    set default_external_location = adapter.generate_seeds_s3_write_path(
+    set default_external_location = adapter.generate_s3_write_path(
       env_name,
       domain_name,
       database_name,
-      table_name
+      table_name,
+      false
     )
   -%}
 

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -22,14 +22,12 @@
   {%- endif -%}
   {%- set file_name = split_model_path[-1].split('.')[0] -%}
   {%- set table_name = file_name.split('__')[-1] -%}
-  {%- set run_time = run_started_at.strftime('%Y-%m-%d %H:%M:%S') -%}
   {%-
-    set default_external_location = adapter.generate_s3_data_path(
+    set default_external_location = adapter.generate_seeds_s3_write_path(
       env_name,
       domain_name,
       database_name,
-      table_name,
-      run_time
+      table_name
     )
   -%}
 

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -28,7 +28,7 @@
       domain_name,
       database_name,
       table_name,
-      seeds
+      'seeds'
     )
   -%}
 

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -28,7 +28,7 @@
       domain_name,
       database_name,
       table_name,
-      false
+      seeds
     )
   -%}
 

--- a/dbt/include/athena/profile_template.yml
+++ b/dbt/include/athena/profile_template.yml
@@ -1,8 +1,11 @@
 fixed:
   type: athena
 prompts:
-  query_dump_bucket:
+  s3_staging_dir:
     hint: S3 location to store Athena query results and metadata
+
+  s3_data_dir:
+    hint: S3 location to store output data created by dbt
 
   region_name:
     hint: AWS region of your Athena instance

--- a/dbt/include/athena/profile_template.yml
+++ b/dbt/include/athena/profile_template.yml
@@ -1,7 +1,7 @@
 fixed:
   type: athena
 prompts:
-  s3_staging_dir:
+  query_dump_bucket:
     hint: S3 location to store Athena query results and metadata
 
   region_name:

--- a/dbt/include/athena/sample_profiles.yml
+++ b/dbt/include/athena/sample_profiles.yml
@@ -3,18 +3,18 @@ default:
 
     dev:
       type: athena
-      query_dump_bucket: s3_staging_dir
-      data_bucket: s3_data_bucket
+      s3_staging_dir: [s3_staging_dir]
+      s3_data_dir: [s3_data_dir]
       region_name: [region_name]
       database: [database name]
       schema: [dev_schema]
 
     prod:
       type: athena
-      query_dump_bucket: s3_staging_dir
-      data_bucket: s3_data_bucket
-      region_name: [ region_name ]
-      database: [ database name ]
-      schema: [ prod_schema ]
+      s3_staging_dir: [s3_staging_dir]
+      s3_data_dir: [s3_data_dir]
+      region_name: [region_name]
+      database: [database name]
+      schema: [prod_schema]
 
   target: dev

--- a/dbt/include/athena/sample_profiles.yml
+++ b/dbt/include/athena/sample_profiles.yml
@@ -3,14 +3,16 @@ default:
 
     dev:
       type: athena
-      s3_staging_dir: [s3_staging_dir]
+      query_dump_bucket: s3_staging_dir
+      data_bucket: s3_data_bucket
       region_name: [region_name]
       database: [database name]
       schema: [dev_schema]
 
     prod:
       type: athena
-      s3_staging_dir: [ s3_staging_dir ]
+      query_dump_bucket: s3_staging_dir
+      data_bucket: s3_data_bucket
       region_name: [ region_name ]
       database: [ database name ]
       schema: [ prod_schema ]


### PR DESCRIPTION
This PR:
- adds a separate method to generate the S3 write path for seeds
- adds references to the `s3_data_dir` required in the dbt profile
- updates the macros used to materialise models and seeds